### PR TITLE
Install php package + enable modules + fix mpm

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 #
 
 default['zoneminder']['use_ppa'] = 'true'
+default['apache']['mpm'] = 'prefork'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,9 @@ maintainer_email 'matt@chef.io'
 license          'Apache 2.0'
 description      'Installs zoneminder security camera software'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '1.0.0'
 supports         'ubuntu'
 supports         'debian'
 source_url       'https://github.com/mattray/zoneminder-cookbook' if respond_to?(:source_url)
 issues_url       'https://github.com/mattray/zoneminder-cookbook/issues' if respond_to?(:issues_url)
+depends          'apache2'


### PR DESCRIPTION
Get the system closer to the install guide provided by Zoneminder. This would still require the user to setup the DB and modify php.ini, but we're closer.

Signed-off-by: Tim Smith tsmith@chef.io
